### PR TITLE
Remove redundant get_* functions in repo_processor

### DIFF
--- a/compiler/repo_processor.py
+++ b/compiler/repo_processor.py
@@ -2,18 +2,6 @@ import re
 import urllib2
 from urlparse import urlparse, urljoin
 
-
-def generate_default_file_name(repo_info):
-    return './.temp/' + repo_info['repo_name'] + '_defaults.yaml'
-
-
-def generate_config_schema_file_name(repo_info):
-    return './.temp/' + repo_info['repo_name'] + '_schema.yaml'
-
-
-def generate_meta_info_file_name(repo_info):
-    return './.temp/' + repo_info['repo_name'] + '_info.yaml'
-
 def get_file_location(repo_info, file_type):
     base = "./.temp/" + repo_info["repo_name"]
 
@@ -86,13 +74,3 @@ def get_repo_file(repo_url, file_name, file_type, post_func=None):
 
     except Exception as ex:
         print(ex.message)
-
-
-def get_meta_info(repo_url):
-    return get_repo_file(repo_url, "meta-info.yaml", "meta_info", augment_meta_info)
-
-def get_default_values(repo_url, default_file_name):
-    return get_repo_file(repo_url, default_file_name, "defaults")
-
-def get_config_schema(repo_url):
-    return get_repo_file(repo_url, "config-schema.yaml", "config_schema")

--- a/simple_grid_yaml_compiler.py
+++ b/simple_grid_yaml_compiler.py
@@ -10,14 +10,14 @@ from shutil import copyfile
 # OUTPUT: include statements for default files and meta-info files of repositories + raw site level-config file
 def phase_1(site_level_configuration_file):
     # fetch repo and get default_values.yaml
-    main_default_values_file = repo_processor.get_default_values("https://github.com/WLCG-Lightweight-Sites/simple_grid_site_defaults", "site_level_configuration_defaults.yaml" )
+    main_default_values_file = repo_processor.get_file_location("https://github.com/WLCG-Lightweight-Sites/simple_grid_site_defaults", "site_level_configuration_defaults.yaml", "defaults")
     repo_urls = lexemes.get_repo_list(site_level_configuration_file)
     print(repo_urls)
     file_names_repository_default = [main_default_values_file]
     file_names_repository_meta = []
     for url in repo_urls:
-        file_names_repository_default.append(repo_processor.get_default_values(url, 'default-data.yaml'))
-        file_names_repository_meta.append(repo_processor.get_meta_info(url).name)
+        file_names_repository_default.append(repo_processor.get_file_location(url, 'default-data.yaml', "defaults"))
+        file_names_repository_meta.append(repo_processor.get_repo_file(repo_url, "meta-info.yaml", "meta_info", augment_meta_info))
     all_includes = file_names_repository_meta + file_names_repository_default
     includes_yaml_file = yaml_augmentation.add_include_statements(all_includes, site_level_configuration_file)
     return includes_yaml_file, repo_urls
@@ -54,15 +54,15 @@ def phase_5(phase_4_output, runtime_vars, yaml):
                 for component_section in lightweight_component:
                     if component_section == 'config':
                         repo_url = lightweight_component['repository_url']
-                        repo_processor.get_config_schema(repo_url)
-                        repo_processor.get_meta_info(repo_url)
+                        repo_processor.get_repo_file(repo_url, "config-schema.yaml", "config_schema")
+                        repo_processor.get_repo_file(repo_url, "meta-info.yaml", "meta_info", augment_meta_info)
                         repo_info = repo_processor.analyse_repo_url(repo_url)
-                        config_schema_file_name = repo_processor.generate_config_schema_file_name(repo_info)
+                        config_schema_file_name = repo_processor.get_file_location(repo_info, "config_schema")
                         config_schema_file = open(config_schema_file_name, 'r')
-                        meta_info_file = repo_processor.generate_meta_info_file_name(repo_info)
+                        meta_info_file = repo_processor.get_file_location(repo_info, "meta_info")
                         meta_info_parent_name = repo_processor.generate_meta_info_parent_name(meta_info_file)
                         meta_info = data[meta_info_parent_name]
-                        default_data_file_name = repo_processor.generate_default_file_name(repo_info)
+                        default_data_file_name = repo_processor.get_file_location(repo_info, "defaults")
                         default_data_runtime_file = open(default_data_file_name + ".runtime", 'w')
                         default_data_file = open(default_data_file_name, 'r')
                         default_data_runtime_file.write(runtime_vars)

--- a/tests/tests_repo_processor.py
+++ b/tests/tests_repo_processor.py
@@ -55,7 +55,7 @@ class RepoProcessorTest(unittest.TestCase):
 		repo_url      = "https://github.com/WLCG-Lightweight-Sites/simple_grid_site_defaults"
 		defaults_file = "site_level_configuration_defaults.yaml"
 
-		fname  = get_default_values(repo_url, defaults_file)
+		fname  = get_repo_file(repo_url, defaults_file, "defaults")
 
 		with open(fname, "r") as file:
 			output = file.read()
@@ -68,7 +68,7 @@ class RepoProcessorTest(unittest.TestCase):
 	def test_get_config_schema(self):
 		repo_url = "https://github.com/WLCG-Lightweight-Sites/wlcg_lightweight_site_ce_cream"
 
-		get_config_schema(repo_url)
+		get_repo_file(repo_url, "config-schema.yaml", "config_schema")
 
 		repo_info = analyse_repo_url(repo_url)
 		fname     = get_file_location(repo_info, "config_schema")
@@ -84,7 +84,7 @@ class RepoProcessorTest(unittest.TestCase):
 	def test_get_meta_info(self):
 		repo_url = "https://github.com/WLCG-Lightweight-Sites/wlcg_lightweight_site_ce_cream"
 
-		get_meta_info(repo_url)
+		get_repo_file(repo_url, "meta-info.yaml", "meta_info", augment_meta_info)
 
 		repo_info = analyse_repo_url(repo_url)
 		fname     = get_file_location(repo_info, "meta_info")

--- a/tests/tests_repo_processor.py
+++ b/tests/tests_repo_processor.py
@@ -1,4 +1,4 @@
-from compiler.repo_processor import analyse_repo_url, generate_default_file_name, generate_config_schema_file_name, generate_meta_info_file_name, get_default_values, get_config_schema, get_meta_info, augment_meta_info, generate_meta_info_parent_name, get_file_location
+from compiler.repo_processor import analyse_repo_url, get_file_location, augment_meta_info, generate_meta_info_parent_name, get_repo_file
 
 from os import mkdir, remove
 from shutil import rmtree

--- a/tests/tests_repo_processor.py
+++ b/tests/tests_repo_processor.py
@@ -1,4 +1,4 @@
-from compiler.repo_processor import analyse_repo_url, generate_default_file_name, generate_config_schema_file_name, generate_meta_info_file_name, get_default_values, get_config_schema, get_meta_info, augment_meta_info, generate_meta_info_parent_name
+from compiler.repo_processor import analyse_repo_url, generate_default_file_name, generate_config_schema_file_name, generate_meta_info_file_name, get_default_values, get_config_schema, get_meta_info, augment_meta_info, generate_meta_info_parent_name, get_file_location
 
 from os import mkdir, remove
 from shutil import rmtree
@@ -27,7 +27,7 @@ class RepoProcessorTest(unittest.TestCase):
 
 		expected_output = "./.temp/simple_grid_yaml_compiler_defaults.yaml"
 
-		self.assertEqual(generate_default_file_name(repo_info), expected_output)
+		self.assertEqual(get_file_location(repo_info, "defaults"), expected_output)
 
 	def test_generate_config_schema_file_name(self):
 		repo_info = {
@@ -38,7 +38,7 @@ class RepoProcessorTest(unittest.TestCase):
 
 		expected_output = "./.temp/simple_grid_yaml_compiler_schema.yaml"
 
-		self.assertEqual(generate_config_schema_file_name(repo_info), expected_output)
+		self.assertEqual(get_file_location(repo_info, "config_schema"), expected_output)
 
 	def test_generate_meta_info_file_name(self):
 		repo_info = {
@@ -49,7 +49,7 @@ class RepoProcessorTest(unittest.TestCase):
 
 		expected_output = "./.temp/simple_grid_yaml_compiler_info.yaml"
 
-		self.assertEqual(generate_meta_info_file_name(repo_info), expected_output)
+		self.assertEqual(get_file_location(repo_info, "meta_info"), expected_output)
 
 	def test_get_default_values(self):
 		repo_url      = "https://github.com/WLCG-Lightweight-Sites/simple_grid_site_defaults"
@@ -71,7 +71,7 @@ class RepoProcessorTest(unittest.TestCase):
 		get_config_schema(repo_url)
 
 		repo_info = analyse_repo_url(repo_url)
-		fname     = generate_config_schema_file_name(repo_info)
+		fname     = get_file_location(repo_info, "config_schema")
 
 		with open(fname, "r") as file:
 			output = file.read()
@@ -87,7 +87,7 @@ class RepoProcessorTest(unittest.TestCase):
 		get_meta_info(repo_url)
 
 		repo_info = analyse_repo_url(repo_url)
-		fname     = generate_meta_info_file_name(repo_info)
+		fname     = get_file_location(repo_info, "meta_info")
 
 		with open(fname, "r") as file:
 			output = file.read()


### PR DESCRIPTION
Solves #36 

Added ```get_repo_file(repo_url, file_name, file_type, post_func=None)```

Introduced two more arguments `file_type` and `post_func`

- `file_type` is used for determining location of file in `.temp` folder - having this argument allows for flexibility with `file_name` in repos
- `post_func` is reference to a function that is applied to the file after its download.

Also added `get_file_location` function to generate file location from `file_type`.

Would appreciate reviews.

Thanks!